### PR TITLE
[14.0][IMP] delivery_purchase_label: Link on label to purchase order

### DIFF
--- a/delivery_purchase_label/models/__init__.py
+++ b/delivery_purchase_label/models/__init__.py
@@ -1,3 +1,4 @@
 from . import delivery_carrier
 from . import mail_compose_message
 from . import purchase_order
+from . import stock_picking

--- a/delivery_purchase_label/models/purchase_order.py
+++ b/delivery_purchase_label/models/purchase_order.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import SUPERUSER_ID, _, api, fields, models
@@ -150,4 +151,5 @@ class PurchaseOrder(models.Model):
             "location_id": self.partner_id.property_stock_supplier.id,
             "company_id": self.company_id.id,
             "carrier_id": carrier.id,
+            "delivery_label_purchase_id": self.id,
         }

--- a/delivery_purchase_label/models/stock_picking.py
+++ b/delivery_purchase_label/models/stock_picking.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    delivery_label_purchase_id = fields.Many2one(
+        "purchase.order", string="Delivery label purchase order", ondelete="cascade"
+    )

--- a/delivery_purchase_label/readme/CONTRIBUTORS.rst
+++ b/delivery_purchase_label/readme/CONTRIBUTORS.rst
@@ -1,4 +1,5 @@
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Design
 ~~~~~~

--- a/delivery_purchase_label/tests/test_delivery_purchase_label.py
+++ b/delivery_purchase_label/tests/test_delivery_purchase_label.py
@@ -63,11 +63,15 @@ class TestDeliveryPurchaseLabel(SavepointCase):
         # Does not change the picking label
         self.order._generate_purchase_delivery_label()
         self.assertEqual(label_picking, self.order.delivery_label_picking_id)
+        self.assertEqual(label_picking.delivery_label_purchase_id, self.order)
         # Changing the PO
         self.order.order_line[0].product_qty = 10
         self.order._generate_purchase_delivery_label()
         self.assertTrue(label_picking.state == "cancel")
         self.assertTrue(label_picking != self.order.delivery_label_picking_id)
+        self.assertEqual(
+            self.order.delivery_label_picking_id.delivery_label_purchase_id, self.order
+        )
 
     def test_transfer_label_not_generated(self):
         self.carrier.purchase_label_picking_type = False


### PR DESCRIPTION
Add many2one field on delivery label transfer to purchase order

This makes it much easier to find delivery purchase label transfers. 

cc @TDu 